### PR TITLE
Fix file name casing

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -160,11 +160,11 @@ Your `app.component.html` should be changed to following minimal structure:-
 
 
 ## Contributing
-We welcome contributions, please see our [Contribution Policy](https://github.com/US-CBP/open-source-policy/blob/master/CONTRIBUTING.md)
+We welcome contributions, please see our [Contribution Policy](https://github.com/US-CBP/open-source-policy/blob/master/CONTRIBUTING.MD)
 
-To get started developing, see contributing readme [here](./CONTRIBUTING.md).
+To get started developing, see contributing readme [here](./CONTRIBUTING.MD).
 
 ## License
-Please refer to [CBP Open Source License](https://github.com/US-CBP/open-source-policy/blob/master/LICENSE.md)
+Please refer to [CBP Open Source License](https://github.com/US-CBP/open-source-policy/blob/master/LICENSE.MD)
 
 


### PR DESCRIPTION
README had wrong case for CONTRIBUTING.MD and LICENSE.MD causing 404 responses when following links to those pages.