### PR TITLE
fixed flex-layout issue with fxFlex="" vs fxFlex="auto"

### DIFF
--- a/src/app/applications/applications-menu/applications-menu.component.html
+++ b/src/app/applications/applications-menu/applications-menu.component.html
@@ -19,7 +19,7 @@
     <div class="cbp-menu-item-category" *ngIf="applicationsData.recents?.length > 0">Recent Apps</div>
     <div class="mat-menu-item" *ngFor="let app of applicationsData.recents">
       <div class="cbp-applications-remove-icon"><mat-icon  fontSet="fontawesome" fontIcon="fa-times" (click)="removeFromRecent(app, $event)" fxFlexAlign="center"></mat-icon></div>
-      <a class="cbp-applications-link"  title="{{app.description}}" href="{{app.href}}" fxFlex="" >
+      <a class="cbp-applications-link"  title="{{app.description}}" href="{{app.href}}" fxFlex="auto" >
         {{app.name}}
       </a>
     </div>
@@ -28,7 +28,7 @@
 
     <div class="cbp-menu-item-category" *ngIf="applicationsData.favorites?.length > 0">Favorite Apps</div>
     <div class="mat-menu-item" *ngFor="let app of applicationsData.favorites">
-      <a class="cbp-applications-link"  title="{{app.description}}" href="{{app.href}}" fxFlex="" >
+      <a class="cbp-applications-link"  title="{{app.description}}" href="{{app.href}}" fxFlex="auto" >
         {{app.name}}
       </a>
     </div>

--- a/src/app/applications/applications-menu/applications-menu.component.ts
+++ b/src/app/applications/applications-menu/applications-menu.component.ts
@@ -45,7 +45,7 @@ export class CBPApplicationsMenuComponent implements OnInit, OnDestroy {
                                 this.isXS = false;
                             });
                         } else {
-                            if (this.cbpMenuTrigger) {
+                            if (this.cbpMenuTrigger && this.cbpMenuTrigger.menu) {
                                 this.isApplicationsExpanded = false;
                                 this.cbpMenuTrigger.closeMenu();
                             }

--- a/src/app/applications/applications-search/applications-search.component.html
+++ b/src/app/applications/applications-search/applications-search.component.html
@@ -6,7 +6,7 @@
 </form>
 <ng-container *ngIf="searchResults">
   <div class="mat-menu-item cbp-app-search-results" *ngFor="let app of searchResultsApplications | async">
-    <a class="cbp-applications-link" title="{{app.description}}" href="{{app.href}}" fxFlex="" >
+    <a class="cbp-applications-link" title="{{app.description}}" href="{{app.href}}" fxFlex="auto" >
       {{app.name}}
     </a>
   </div>

--- a/src/app/header/app-header/app-header.component.html
+++ b/src/app/header/app-header/app-header.component.html
@@ -11,7 +11,7 @@
 
 
 
-  <div class="app-header-right-nav-container cbp-toolbar-right-nav" fxFlex=""  fxFlexAlign.gt-xs="end" fxLayoutAlign.gt-xs="end stretch" fxLayout.gt-xs="row" fxLayout.lt-sm="column" >
+  <div class="app-header-right-nav-container cbp-toolbar-right-nav" fxFlex="auto"  fxFlexAlign.gt-xs="end" fxLayoutAlign.gt-xs="end stretch" fxLayout.gt-xs="row" fxLayout.lt-sm="column" >
     <ng-content select="cbp-app-right-nav"></ng-content>
   </div>
 

--- a/src/app/header/cbp-header/cbp-header.component.html
+++ b/src/app/header/cbp-header/cbp-header.component.html
@@ -11,8 +11,8 @@
   </div>
 
   <div class="cbp-toolbar-right-nav"  fxFlexAlign.gt-xs="end"  fxLayout.gt-xs="row" fxLayout.lt-sm="column">
-    <div fxFlex=""><ng-template [ngTemplateOutlet]="feedbackNavItem"></ng-template></div>
-    <div fxFlex=""><ng-template [ngTemplateOutlet]="userNavItem"></ng-template></div>
+    <div fxFlex="auto"><ng-template [ngTemplateOutlet]="feedbackNavItem"></ng-template></div>
+    <div fxFlex="auto"><ng-template [ngTemplateOutlet]="userNavItem"></ng-template></div>
   </div>
 
 

--- a/src/app/header/cbp-toolbar/cbp-toolbar.component.html
+++ b/src/app/header/cbp-toolbar/cbp-toolbar.component.html
@@ -1,6 +1,6 @@
 <div class="cbp-toolbar-row mat-toolbar mat-toolbar-row" fxLayout="row"  [@cbpToolbarState]="cbpToolbarState">
 
-  <div class="cbp-brand-nav-container"  fxFlexAlign="stretch" fxLayout="row">
+  <div class="cbp-brand-nav-container"  fxFlexAlign="stretch" >
     <ng-content select=".cbp-toolbar-title"></ng-content>
   </div>
 
@@ -8,11 +8,11 @@
     <ng-template [ngTemplateOutlet]="cbpToolbarMainNav"></ng-template>
   </div>
 
-  <div class="cbp-toolbar-right-nav-container" *ngIf="isToolbarExpanded ? false : true" fxFlex=""   fxShow="false" fxShow.gt-xs>
+  <div class="cbp-toolbar-right-nav-container" *ngIf="isToolbarExpanded ? false : true" fxFlex="auto"   fxShow="false" fxShow.gt-xs>
     <ng-template [ngTemplateOutlet]="cbpToolbarRightNav"></ng-template>
   </div>
 
-  <div fxFlex="" fxFlexOrder.lt-sm="1"  class="cbp-toolbar-expansion-container" fxFlexAlign="stretch" fxLayout="row" fxLayoutAlign="end stretch" fxHide="false" fxHide.gt-xs>
+  <div fxFlex="auto" fxFlexOrder.lt-sm="1"  class="cbp-toolbar-expansion-container" fxFlexAlign="stretch" fxLayout="row" fxLayoutAlign="end stretch" fxHide="false" fxHide.gt-xs>
     <div class="cbp-toolbar-expansion" (click)="isToolbarExpanded = ! isToolbarExpanded">
       <div class="cbp-toolbar-expansion-icon">
         <span class="icon-bar"></span>

--- a/src/demo/app/demo-app-header/demo-app-header.component.html
+++ b/src/demo/app/demo-app-header/demo-app-header.component.html
@@ -34,7 +34,7 @@
 <ng-template #stackedAppNav>
     <ng-container>
         <div class="mat-menu-item" *ngFor="let appNav of appNavigations">
-            <div title="{{appNav.name}}"  fxFlex="" >
+            <div title="{{appNav.name}}"  fxFlex="auto" >
                 {{appNav.name}}
             </div>
         </div>

--- a/src/demo/app/demo-app-header/demo-app-header.component.scss
+++ b/src/demo/app/demo-app-header/demo-app-header.component.scss
@@ -2,10 +2,12 @@
 
 .app-right-nav-items {
   display: inline-flex;
+
 }
 
 .app-title {
   padding: 0 $padding-base-horizontal;
+
   margin-top: 10px;
   &.vertical-divider {
     border-right: 1px solid $brand-default-border;


### PR DESCRIPTION
Right nav items of headers were not showing up in IE 11. @dave-r suggested `auto` and found the following hence the PR:-
`fxFlex=""` results into `flex: 1 1 0px` in IE and `flex: 1 1 1e-09px` in Chrome and other browsers.
This results into IE not behaving correctly causing the right nav items on header to not show up in IE 11.
IE needs `auto` in most cases. This fix replaces `fxFlex=""` to `fxFlex="auto"` and other minor App header related issue.